### PR TITLE
Cambio en la vista para poder visualizar ambas metas de los 2 turnos

### DIFF
--- a/lib/core/controller/metas_controller.dart
+++ b/lib/core/controller/metas_controller.dart
@@ -133,14 +133,19 @@ class MetasController extends ChangeNotifier {
     return await _metasService.obtenerTodasMetas();
   }
 
-  Future<int> obtenerSumaPasajerosSemanaActualTurnoActual() async {
+//   Future<int> obtenerSumaPasajerosSemanaActualTurnoActual() async {
+//   final fechaHoy = DateTime.now();
+//   final rango = _finanzasService.obtenerRangoPorFecha(fechaHoy, FiltroPeriodo.semana);
+//   final turno = Formatters.getTurnoActual().name; // O pásalo como String si tu servicio lo pide
+//   // Si quieres todos los turnos, pásalo sin turno: reservasService.obtenerSumaPasajerosPorRango(rango.start, rango.end)
+//   return await _reservasService.obtenerSumaPasajerosPorRango(rango.start, rango.end, turno: turno);
+// }
+  
+Future<int> obtenerSumaPasajerosSemanaActualTurno(TurnoType turno) async {
   final fechaHoy = DateTime.now();
   final rango = _finanzasService.obtenerRangoPorFecha(fechaHoy, FiltroPeriodo.semana);
-  final turno = Formatters.getTurnoActual().name; // O pásalo como String si tu servicio lo pide
-  // Si quieres todos los turnos, pásalo sin turno: reservasService.obtenerSumaPasajerosPorRango(rango.start, rango.end)
-  return await _reservasService.obtenerSumaPasajerosPorRango(rango.start, rango.end, turno: turno);
+  return await _reservasService.obtenerSumaPasajerosPorRango(rango.start, rango.end, turno: turno.name);
 }
-  
 
   /// Obtiene la meta activa para la semana actual usando el turno actual (mañana o tarde).
   Future<double?> obtenerMetaSemanaActualTurnoActual() async {


### PR DESCRIPTION
This pull request refactors the weekly goals reporting logic to display progress for both morning and afternoon shifts, rather than just the current shift. The changes improve the flexibility and clarity of the metas (goals) card in the reports view and enhance layout responsiveness.

**Metas (Goals) reporting improvements:**

* Changed the metas progress card to show both morning and afternoon shift data by updating the logic to fetch and display goals and progress for each shift (`_obtenerDatosMetaDiaCompleto`) instead of only the current shift. [[1]](diffhunk://#diff-e267544e216203108a1c0463e226a5ba99cb6cc40e91604a22e354edab7f5a6bL892-R892) [[2]](diffhunk://#diff-e267544e216203108a1c0463e226a5ba99cb6cc40e91604a22e354edab7f5a6bL934-R940) [[3]](diffhunk://#diff-e267544e216203108a1c0463e226a5ba99cb6cc40e91604a22e354edab7f5a6bR1036-R1084)
* Updated the message shown when no goal is defined to refer to the day rather than the shift, reflecting the new dual-shift display.
* Refactored the calculation and display of progress to handle each shift separately, including a helper function for building each row. [[1]](diffhunk://#diff-e267544e216203108a1c0463e226a5ba99cb6cc40e91604a22e354edab7f5a6bL934-R940) [[2]](diffhunk://#diff-e267544e216203108a1c0463e226a5ba99cb6cc40e91604a22e354edab7f5a6bL962-R966)
* Deprecated the old single-shift goal fetching logic and replaced it with a new method in `MetasController` that supports specifying the shift (`obtenerSumaPasajerosSemanaActualTurno`).

**UI and layout enhancements:**

* Switched from `Expanded` to `Flexible` for navigation cards and added `crossAxisAlignment: CrossAxisAlignment.start` to improve responsiveness and alignment in the cards row layout. [[1]](diffhunk://#diff-e267544e216203108a1c0463e226a5ba99cb6cc40e91604a22e354edab7f5a6bR723-R727) [[2]](diffhunk://#diff-e267544e216203108a1c0463e226a5ba99cb6cc40e91604a22e354edab7f5a6bL756-R758)
* Removed fixed height from the metas card container to allow for dynamic sizing based on content.
* Minor cleanups, such as removing unused comments and clarifying provider usage.