### PR TITLE
Se coloco de manera predeterminada el Turno Tarde

### DIFF
--- a/lib/screens/reportes/vista_reportes.dart
+++ b/lib/screens/reportes/vista_reportes.dart
@@ -71,7 +71,8 @@ class _ReportesViewState extends State<ReportesView>
     //   _filtrosController.agregarSemana(now.subtract(Duration(days: 7 * i)));
     // }
   _weeklyFiltrosController.seleccionarPeriodo(FiltroPeriodo.semana);
-    _weeklyFiltrosController.seleccionarSemana(DateTime.now());
+  _weeklyFiltrosController.seleccionarSemana(DateTime.now());
+  _weeklyFiltrosController.seleccionarTurno(TurnoType.tarde); // Cambio para que sea predeterminado sapo :v
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final gastosController = Provider.of<GastosController>(context, listen: false);
       gastosController.cargarTodosLosGastos();


### PR DESCRIPTION
This pull request introduces a small change to the default filter settings in the `ReportesView` screen. The change sets the default shift filter to "tarde" (afternoon) when the weekly filters are initialized.

* Sets the default value of the shift filter to `TurnoType.tarde` in `_weeklyFiltrosController` during initialization in `lib/screens/reportes/vista_reportes.dart`.